### PR TITLE
Add git & g++ package (needed for gems from git repos)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN set -ex \
   readline-dev \
   ruby \
   git \
+  g++ \
   tar \
   xz \
   yaml-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN set -ex \
   procps \
   readline-dev \
   ruby \
+  git \
   tar \
   xz \
   yaml-dev \


### PR DESCRIPTION
Without git installed i cannot use gems from git repos.
Bundler gives me this message "You need to install git to be able to use gems from git repositories."